### PR TITLE
Updated the Player Listener to non-deprecated events

### DIFF
--- a/src/main/java/com/cypherx/xauth/listeners/xAuthPlayerListener.java
+++ b/src/main/java/com/cypherx/xauth/listeners/xAuthPlayerListener.java
@@ -132,7 +132,7 @@ public class xAuthPlayerListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onPlayerChat(PlayerChatEvent event) {
+    public void onPlayerChat(AsyncPlayerChatEvent event) {
         xAuthPlayer p = playerManager.getPlayer(event.getPlayer());
         if (playerManager.isRestricted(p, event)) {
             playerManager.sendNotice(p);


### PR DESCRIPTION
Changed PlayerChatEvent to AsyncPlayerChatEvent since PlayerChatEvent is
deprecated.
Haven't been able to test this to see if it would cause any errors, however.
