### PR TITLE
Added to xAuthLoginEvent and xAuthPlayerJoinEvent the player which logged in

### DIFF
--- a/src/main/java/de/luricos/bukkit/xAuth/commands/LoginCommand.java
+++ b/src/main/java/de/luricos/bukkit/xAuth/commands/LoginCommand.java
@@ -69,7 +69,7 @@ public class LoginCommand extends xAuthCommand implements CommandExecutor {
                 response = "login.success";
                 a.online(playerName);
 
-                this.callEvent(xAuthLoginEvent.Action.PLAYER_LOGIN, xp.getStatus());
+                this.callEvent(xAuthLoginEvent.Action.PLAYER_LOGIN, xp.getStatus(), xp);
 
                 xAuthLog.info(playerName + " authenticated");
             } else {

--- a/src/main/java/de/luricos/bukkit/xAuth/commands/xAuthCommand.java
+++ b/src/main/java/de/luricos/bukkit/xAuth/commands/xAuthCommand.java
@@ -48,8 +48,8 @@ public class xAuthCommand {
         Bukkit.getPluginManager().callEvent(event);
     }
 
-    protected void callEvent(final xAuthLoginEvent.Action action, final xAuthPlayer.Status status) {
-        this.callEvent(new xAuthLoginEvent(action, status));
+    protected void callEvent(final xAuthLoginEvent.Action action, final xAuthPlayer.Status status, xAuthPlayer player) {
+        this.callEvent(new xAuthLoginEvent(action, status, player));
     }
 
     protected void callEvent(final xAuthLogoutEvent event) {

--- a/src/main/java/de/luricos/bukkit/xAuth/events/xAuthLoginEvent.java
+++ b/src/main/java/de/luricos/bukkit/xAuth/events/xAuthLoginEvent.java
@@ -28,14 +28,20 @@ import org.bukkit.event.HandlerList;
 public class xAuthLoginEvent extends xAuthEvent {
     protected Action action;
     protected xAuthPlayer.Status status;
+    protected xAuthPlayer player;
 
     private static final HandlerList handlers = new HandlerList();
-
+    
     public xAuthLoginEvent(Action action, xAuthPlayer.Status status) {
+    	this(action, status, null);    	
+    }
+
+    public xAuthLoginEvent(Action action, xAuthPlayer.Status status, xAuthPlayer player) {
         super(action.toString());
 
         this.action = action;
         this.status = status;
+        this.player = player;
     }
 
     public Action getAction() {
@@ -57,5 +63,10 @@ public class xAuthLoginEvent extends xAuthEvent {
 
     public enum Action {
         PLAYER_LOGIN
+    }
+    
+    public xAuthPlayer getPlayer()
+    {
+    	return player;
     }
 }

--- a/src/main/java/de/luricos/bukkit/xAuth/events/xAuthPlayerJoinEvent.java
+++ b/src/main/java/de/luricos/bukkit/xAuth/events/xAuthPlayerJoinEvent.java
@@ -21,17 +21,25 @@ package de.luricos.bukkit.xAuth.events;
 
 import org.bukkit.event.HandlerList;
 
+import de.luricos.bukkit.xAuth.xAuthPlayer;
+
 /**
  * @author lycano
  */
 public class xAuthPlayerJoinEvent extends xAuthEvent {
     protected Action action;
     private static final HandlerList handlers = new HandlerList();
+    protected xAuthPlayer player = null;
 
     public xAuthPlayerJoinEvent(Action action) {
+    	this(action, null);
+    }
+    
+    public xAuthPlayerJoinEvent(Action action, xAuthPlayer player) {
         super(action.toString());
 
         this.action = action;
+        this.player = player;
     }
 
     public Action getAction() {
@@ -49,5 +57,10 @@ public class xAuthPlayerJoinEvent extends xAuthEvent {
 
     public enum Action {
         PLAYER_JOINED
+    }
+    
+    public xAuthPlayer getPlayer()
+    {
+    	return player;
     }
 }

--- a/src/main/java/de/luricos/bukkit/xAuth/listeners/xAuthEventListener.java
+++ b/src/main/java/de/luricos/bukkit/xAuth/listeners/xAuthEventListener.java
@@ -121,8 +121,8 @@ public class xAuthEventListener implements Listener {
         Bukkit.getPluginManager().callEvent(event);
     }
 
-    protected void callEvent(final xAuthPlayerJoinEvent.Action action) {
-        this.callEvent(new xAuthPlayerJoinEvent(action));
+    protected void callEvent(final xAuthPlayerJoinEvent.Action action, xAuthPlayer player) {
+        this.callEvent(new xAuthPlayerJoinEvent(action, player));
     }
 
     protected void callEvent(final xAuthPlayerLoginEvent event) {

--- a/src/main/java/de/luricos/bukkit/xAuth/listeners/xAuthPlayerListener.java
+++ b/src/main/java/de/luricos/bukkit/xAuth/listeners/xAuthPlayerListener.java
@@ -128,7 +128,7 @@ public class xAuthPlayerListener extends xAuthEventListener {
 
         playerManager.getTasks().scheduleDelayedPremiumCheck(playerName);
 
-        this.callEvent(xAuthPlayerJoinEvent.Action.PLAYER_JOINED);
+        this.callEvent(xAuthPlayerJoinEvent.Action.PLAYER_JOINED, xp);
     }
 
     @EventHandler(priority = EventPriority.MONITOR)


### PR DESCRIPTION
This is useful if you need some way to know which player did logged in successfully from the event.
Works both on /login command and resume session.