### PR TITLE
fix: column names in create session

### DIFF
--- a/src/main/java/de/luricos/bukkit/xAuth/PlayerManager.java
+++ b/src/main/java/de/luricos/bukkit/xAuth/PlayerManager.java
@@ -829,8 +829,11 @@ public class PlayerManager {
             }
 
             // insert if session does not exist
-            sql = String.format("INSERT INTO `%s` VALUES (?, ?, ?)",
-                    this.getTable(DatabaseTables.SESSION));
+            sql = String.format("INSERT INTO `%s` (`%s`, `%s`, `%s`) VALUES (?, ?, ?)",
+                    this.getTable(DatabaseTables.SESSION),
+                    this.getRow(DatabaseRows.SESSION_ACCOUNTID),
+                    this.getRow(DatabaseRows.SESSION_IPADDRESS),
+                    this.getRow(DatabaseRows.SESSION_LOGINTIME));
 
             ps = conn.prepareStatement(sql);
             ps.setInt(1, accountId);


### PR DESCRIPTION
I was merging your new changes with our old code and noticed that this particular bit of SQL didn't have the column names. It is best to specify which ones, allowing the xauth table to be used for other purposes. Don't you agree?